### PR TITLE
Fix FCS Incorrect error for smaller frames

### DIFF
--- a/enc28j60driver/enc28j60.c
+++ b/enc28j60driver/enc28j60.c
@@ -493,7 +493,9 @@ int enc_read_received_pbuf(enc_device_t *dev, struct pbuf **buf)
 		return 1;
 
 	receive_start(dev, header, &length);
+	length -= 4; /* Drop the 4 byte CRC from length */
 
+	/* pbuf processing looks at the total length of pbuf */
 	*buf = pbuf_alloc(PBUF_RAW, length, PBUF_RAM);
 	if (*buf == NULL)
 		DEBUG("failed to allocate buf of length %u, discarding", length);


### PR DESCRIPTION
ENC reports ethernet frame len + padding + 4 byte CRC.
When allocating pbuf with recevied frame size, FCS incorrect error
is reported for the transmitted frames which are less than 60 bytes.

LwIP reuses recevied pbuf for transmission if possible, hence the
pbuf total length is > 60 bytes (64 bytes) which causes this FCS error.

If you look at wireshark, the rx frame CRC is reported back to host. The
expected packet is always 60 bytes for frame < 60 bytes but on host its
reported with 64 bytes.

Signed-off-by: Ajay Bhargav contact@rickeyworld.info
